### PR TITLE
[Feat] 가사 정렬

### DIFF
--- a/Halmap/View/SongInformation/SongContentView.swift
+++ b/Halmap/View/SongInformation/SongContentView.swift
@@ -13,18 +13,23 @@ struct SongContentView: View {
     @Binding var music: Music
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 20){
-            Text("가사")
-                .foregroundColor(Color("\(selectedTeam)Background"))
-                .font(.caption)
-                .bold()
-            Text(music.lyric)
-                .foregroundColor(.black)
-                .font(.body)
-            Spacer()
-        }.padding([.horizontal, .top])
         
-        
+        ScrollView(showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 20) {
+                
+                Text("가사")
+                    .foregroundColor(Color("\(selectedTeam)Background"))
+                    .font(.Halmap.CustomCaptionBold)
+                
+                Text(music.lyric)
+                    .foregroundColor(.black)
+                    .font(.Halmap.CustomBodyMedium)
+                    .lineSpacing(10)
+                
+                Spacer()
+            }
+            .padding(20)
+        }
     }
 }
 

--- a/Halmap/View/SongInformation/SongInformationView.swift
+++ b/Halmap/View/SongInformation/SongInformationView.swift
@@ -13,17 +13,19 @@ struct SongInformationView: View {
     @State var music: Music
     
     var body: some View {
-        VStack{
+        VStack(alignment: .leading) {
+            
             SongHeaderView(music: $music)
                 .frame(width: UIScreen.main.bounds.width + 3,
                        height: 156)
                 .background(Color("songGrey"))
             
             SongContentView(music: $music)
-                .frame(width: UIScreen.main.bounds.width + 3)
                 .background(.white)
+            
             Spacer()
-        }.ignoresSafeArea()
+        }
+        .ignoresSafeArea()
     }
 }
 


### PR DESCRIPTION
### 관련 이슈
- closes #50

### 구현한 기능
- 가사 정렬
- 할맵 폰트 적용
- 가사에 스크롤뷰 적용

### 스크린샷
|최종 화면|HIFi|
|---|---|
|<img src = "https://user-images.githubusercontent.com/68676844/200118546-f8f7cb8a-4c48-4412-8e38-941ddb063d68.png" width = 250>|<img src = "https://user-images.githubusercontent.com/68676844/200118575-60566e05-350f-4d55-a8e4-e07c5d0223e7.png" width = 250>

